### PR TITLE
Migrate from darken to filter for sass-embedded compatibility

### DIFF
--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -746,12 +746,12 @@ export default withStyles(({ reactDates: { color, zIndex } }) => ({
     zIndex: zIndex + 2,
 
     ':hover': {
-      color: `darken(${color.core.grayLighter}, 10%)`,
+      filter: brightness(0.9),
       textDecoration: 'none',
     },
 
     ':focus': {
-      color: `darken(${color.core.grayLighter}, 10%)`,
+      filter: brightness(0.9),
       textDecoration: 'none',
     },
   },

--- a/src/components/SingleDatePicker.jsx
+++ b/src/components/SingleDatePicker.jsx
@@ -697,12 +697,12 @@ export default withStyles(({ reactDates: { color, zIndex } }) => ({
     zIndex: zIndex + 2,
 
     ':hover': {
-      color: `darken(${color.core.grayLighter}, 10%)`,
+      filter: brightness(0.9),
       textDecoration: 'none',
     },
 
     ':focus': {
-      color: `darken(${color.core.grayLighter}, 10%)`,
+      filter: brightness(0.9),
       textDecoration: 'none',
     },
   },


### PR DESCRIPTION
## Motivation

We want to migrate from node-sass to sass-embedded as part of a Node.js v22 upgrade. With `sass-embedded`, `darken` being used in plain CSS files will throw an error.

<!--
### Maybe: Experiment details

| variable | name |
| ----- | ----- |
| experiment name | TODO |
| variants | TODO |
| event names | maybe TODO |
-->

## Changes

<!--
- Changes to the codebase made (try to organize in a logical order, for example, by putting the ultimate change first and putting changes that it depends on after)
- Add some component
- Refactor another component
- Created script, etc.
-->

1. Replace all instances of `darken` with `filter`

## Testing

1. TODO: build this and install; make sure the styles look right on hover 